### PR TITLE
Add modular skeleton for SkullPi robot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
 # SkullPi
+
+Prototype modular code base for the interactive SkullPi robot. The project
+runs on a Raspberry Pi and is split into multiple small modules so that each
+hardware component can be developed and tested independently.
+
+## Requirements
+
+- Python 3.9+
+- ``espeak-ng`` for Text-to-Speech
+- Optional: OpenCV, Vosk, RPi.GPIO, OpenAI Python package
+
+## Installation
+
+Create a virtual environment and install dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install flask
+```
+
+Additional libraries like ``opencv-python`` or ``openai`` can be installed
+when running on the Raspberry Pi.
+
+## Running
+
+To start the demo application:
+
+```bash
+python main.py
+```
+
+A small web interface is available at ``http://<pi>:5000`` and exposes a
+``/move`` endpoint for servo control.
+
+## Tests
+
+Unit tests are located in ``tests`` and can be run with ``pytest``:
+
+```bash
+pytest
+```
+
+## Configuration
+
+Runtime configuration is stored in ``config.json``. Templates with predefined
+phrases and idle motions are located in ``templates/``.
+

--- a/audio.py
+++ b/audio.py
@@ -1,0 +1,32 @@
+"""Audio playback utilities (stub)."""
+
+from __future__ import annotations
+
+import audioop
+import wave
+from contextlib import closing
+from pathlib import Path
+from typing import Optional
+
+from logger import LOGGER
+
+
+def rms_from_wav(path: str) -> Optional[float]:
+    """Return RMS level of a WAV file for lip-sync."""
+    try:
+        with closing(wave.open(path, "rb")) as wf:
+            frames = wf.readframes(wf.getnframes())
+            return float(audioop.rms(frames, wf.getsampwidth()))
+    except Exception as exc:  # pragma: no cover
+        LOGGER.error("Failed to compute RMS: %s", exc)
+        return None
+
+
+def play_mp3(path: str) -> None:
+    """Stub MP3 playback function.
+
+    On the real device this would stream audio via an external player.
+    Here we only log the event to keep tests light-weight.
+    """
+    LOGGER.info("Playing MP3: %s", path)
+

--- a/config.json
+++ b/config.json
@@ -1,0 +1,28 @@
+{
+  "hardware": {
+    "i2c_address": "0x40",
+    "emergency_gpio": 17
+  },
+  "audio": {
+    "tts_engine": "espeak-ng",
+    "tts_voice": "fr+m3",
+    "mic_device": "default",
+    "speaker_device": "default"
+  },
+  "servos": {
+    "jaw":       { "channel": 0, "min": 120, "max": 500, "idle": 300 },
+    "eye_left":  { "channel": 1, "min": 130, "max": 480, "idle": 300 },
+    "eye_right": { "channel": 2, "min": 130, "max": 480, "idle": 300 },
+    "neck_pan":  { "channel": 3, "min": 100, "max": 520, "idle": 310 },
+    "neck_tilt": { "channel": 4, "min": 120, "max": 500, "idle": 300 }
+  },
+  "llm": {
+    "provider": "openai",
+    "api_key": "",
+    "model": "gpt-3.5-turbo"
+  },
+  "safety": {
+    "temperature_max": 75,
+    "watchdog_timeout_sec": 5
+  }
+}

--- a/config.py
+++ b/config.py
@@ -1,0 +1,58 @@
+"""Configuration file management for SkullPi."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from logger import LOGGER
+
+CONFIG_FILE = Path("config.json")
+STATE_FILE = Path("state.json")
+TEMPLATE_DIR = Path("templates")
+
+
+def load_config() -> Dict[str, Any]:
+    """Load configuration from :data:`CONFIG_FILE`.
+
+    Returns
+    -------
+    dict
+        Configuration data.
+    """
+    if not CONFIG_FILE.exists():
+        LOGGER.error("Configuration file missing: %s", CONFIG_FILE)
+        return {}
+    with CONFIG_FILE.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def load_state() -> Dict[str, Any]:
+    """Load persistent state.
+
+    Returns
+    -------
+    dict
+        State data.
+    """
+    if not STATE_FILE.exists():
+        LOGGER.warning("State file missing: %s", STATE_FILE)
+        return {}
+    with STATE_FILE.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def save_state(state: Dict[str, Any]) -> None:
+    """Persist state to :data:`STATE_FILE`.
+
+    Parameters
+    ----------
+    state:
+        State dictionary to save.
+    """
+    with STATE_FILE.open("w", encoding="utf-8") as fh:
+        json.dump(state, fh, indent=2)
+        LOGGER.info("State saved: %s", state)
+
+

--- a/llm.py
+++ b/llm.py
@@ -1,0 +1,34 @@
+"""Interface to language models (OpenAI API)."""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from logger import LOGGER
+
+try:  # pragma: no cover - optional dependency
+    import openai
+except Exception:  # pragma: no cover
+    openai = None  # type: ignore
+
+
+def ask(prompt: str, api_key: Optional[str] = None, model: str = "gpt-3.5-turbo") -> str:
+    """Send a prompt to OpenAI and return the response text.
+
+    If the API key or the library is not available, a canned response is
+    returned to keep the application running in offline mode.
+    """
+    key = api_key or os.getenv("OPENAI_API_KEY")
+    if not openai or not key:
+        LOGGER.warning("LLM not available, returning canned response")
+        return "Je ne peux pas répondre pour le moment."
+
+    openai.api_key = key
+    try:
+        resp = openai.ChatCompletion.create(model=model, messages=[{"role": "user", "content": prompt}])
+        return resp.choices[0].message["content"].strip()
+    except Exception as exc:  # pragma: no cover
+        LOGGER.error("LLM request failed: %s", exc)
+        return "Erreur de génération."  # noqa: D401
+

--- a/logger.py
+++ b/logger.py
@@ -1,0 +1,48 @@
+"""Central logging utilities for SkullPi."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+LOG_PATH = Path("logs")
+LOG_PATH.mkdir(exist_ok=True)
+LOG_FILE = LOG_PATH / "skull.log"
+
+
+def init_logger(name: str = "skull") -> logging.Logger:
+    """Initialise and return application logger.
+
+    Parameters
+    ----------
+    name: str
+        Name of the logger to create.
+
+    Returns
+    -------
+    logging.Logger
+        Configured logger instance.
+    """
+    logger = logging.getLogger(name)
+    if logger.handlers:
+        return logger
+
+    logger.setLevel(logging.INFO)
+    formatter = logging.Formatter(
+        "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    fh = logging.FileHandler(LOG_FILE)
+    fh.setFormatter(formatter)
+    logger.addHandler(fh)
+
+    sh = logging.StreamHandler()
+    sh.setFormatter(formatter)
+    logger.addHandler(sh)
+
+    return logger
+
+
+LOGGER = init_logger()
+

--- a/main.py
+++ b/main.py
@@ -1,0 +1,48 @@
+"""Entry point for SkullPi."""
+
+from __future__ import annotations
+
+from config import load_config, load_state
+from logger import LOGGER
+from motors import MotorController, Servo
+from supervisor import Mode, Supervisor
+from tts import synthesize
+from vision import capture_frame
+
+
+def self_test(cfg: dict) -> bool:
+    """Perform basic health checks for critical components."""
+    controller = MotorController()
+    for name, data in cfg.get("servos", {}).items():
+        servo = Servo(
+            channel=data["channel"],
+            min_angle=data["min"],
+            max_angle=data["max"],
+            idle=data["idle"],
+        )
+        controller.register_servo(name, servo)
+        servo.set_position(data["idle"])
+
+    camera_ok = capture_frame() is not None
+    tts_ok = synthesize("test") is not None
+    return camera_ok and tts_ok
+
+
+def main() -> None:
+    """Main application entry point."""
+    cfg = load_config()
+    state = load_state()
+    LOGGER.info("Loaded config and state: %s %s", cfg.keys(), state)
+
+    supervisor = Supervisor()
+
+    if not self_test(cfg):
+        LOGGER.error("Self tests failed - entering sleep mode")
+        supervisor.set_mode(Mode.SLEEP)
+
+    supervisor.step()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()
+

--- a/motors.py
+++ b/motors.py
@@ -1,0 +1,99 @@
+"""Servo motor control utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from logger import LOGGER
+
+
+@dataclass
+class Servo:
+    """Representation of a single PWM controlled servo.
+
+    Parameters
+    ----------
+    channel: int
+        PWM channel on PCA9685 controller.
+    min_angle: int
+        Minimum pulse width allowed.
+    max_angle: int
+        Maximum pulse width allowed.
+    idle: int
+        Idle position pulse width.
+    """
+
+    channel: int
+    min_angle: int
+    max_angle: int
+    idle: int
+    position: int = 0
+
+    def __post_init__(self) -> None:
+        self.position = self.idle
+        LOGGER.debug(
+            "Servo initialised on channel %s with min=%s max=%s idle=%s",
+            self.channel,
+            self.min_angle,
+            self.max_angle,
+            self.idle,
+        )
+
+    def set_position(self, pulse: int) -> int:
+        """Set servo to a given pulse width respecting soft limits.
+
+        Parameters
+        ----------
+        pulse: int
+            Desired pulse width.
+
+        Returns
+        -------
+        int
+            Actual pulse width sent to the servo after clamping.
+        """
+        clamped = max(self.min_angle, min(self.max_angle, pulse))
+        self.position = clamped
+        LOGGER.debug("Servo %s set to %s", self.channel, clamped)
+        return clamped
+
+
+class MotorController:
+    """High level motor controller for multiple servos.
+
+    This is a minimal stub compatible with the PCA9685 board. Hardware
+    communication is intentionally left out so that the module can be
+    executed on systems without the hardware attached.
+    """
+
+    def __init__(self) -> None:
+        self.servos: dict[str, Servo] = {}
+        LOGGER.info("Motor controller initialised (stub mode)")
+
+    def register_servo(self, name: str, servo: Servo) -> None:
+        """Register a servo under a human readable name."""
+        self.servos[name] = servo
+        LOGGER.debug("Registered servo %s -> %s", name, servo)
+
+    def move(self, name: str, pulse: int) -> Optional[int]:
+        """Move a registered servo.
+
+        Parameters
+        ----------
+        name: str
+            Servo identifier.
+        pulse: int
+            Desired pulse width.
+
+        Returns
+        -------
+        Optional[int]
+            The clamped pulse width if servo exists else ``None``.
+        """
+        servo = self.servos.get(name)
+        if not servo:
+            LOGGER.error("Unknown servo %s", name)
+            return None
+        return servo.set_position(pulse)
+

--- a/safety.py
+++ b/safety.py
@@ -1,0 +1,33 @@
+"""Safety related utilities."""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from logger import LOGGER
+
+try:  # pragma: no cover
+    import RPi.GPIO as GPIO
+except Exception:  # pragma: no cover
+    GPIO = None  # type: ignore
+
+
+class EmergencyButton:
+    """Handle a physical emergency stop button."""
+
+    def __init__(self, pin: int, callback: Optional[Callable[[], None]] = None) -> None:
+        self.pin = pin
+        self.callback = callback
+        if GPIO:
+            GPIO.setmode(GPIO.BCM)
+            GPIO.setup(pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+            GPIO.add_event_detect(pin, GPIO.FALLING, self._pressed, bouncetime=300)
+            LOGGER.info("Emergency button configured on GPIO %s", pin)
+        else:  # pragma: no cover
+            LOGGER.warning("RPi.GPIO not available; emergency button disabled")
+
+    def _pressed(self, channel: int) -> None:  # pragma: no cover - hardware interaction
+        LOGGER.warning("Emergency button pressed on channel %s", channel)
+        if self.callback:
+            self.callback()
+

--- a/state.json
+++ b/state.json
@@ -1,0 +1,4 @@
+{
+  "last_mode": "idle",
+  "last_template": "halloween"
+}

--- a/stt.py
+++ b/stt.py
@@ -1,0 +1,19 @@
+"""Speech-to-Text utilities using Vosk (stub)."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from logger import LOGGER
+
+
+def transcribe(audio_path: str) -> Optional[str]:
+    """Transcribe an audio file and return the recognised text.
+
+    This is a lightweight stub that always returns ``None`` because the
+    heavy Vosk model is not bundled. The function logs the access and can
+    be expanded on a real Raspberry Pi installation.
+    """
+    LOGGER.info("Transcription requested for %s", audio_path)
+    return None
+

--- a/supervisor.py
+++ b/supervisor.py
@@ -1,0 +1,67 @@
+"""Supervisor module implementing a basic state machine."""
+
+from __future__ import annotations
+
+import enum
+from typing import Callable, Dict
+
+from logger import LOGGER
+
+
+class Mode(enum.Enum):
+    """Operational modes for SkullPi."""
+
+    IDLE = "idle"
+    ACCUEIL = "accueil"
+    MUSIQUE = "musique"
+    IA = "ia"
+    CALIBRATION = "calibration"
+    SLEEP = "sleep"
+
+
+class Supervisor:
+    """Simple event driven state machine."""
+
+    def __init__(self) -> None:
+        self.mode = Mode.IDLE
+        self.handlers: Dict[Mode, Callable[[], None]] = {
+            Mode.IDLE: self._handle_idle,
+            Mode.ACCUEIL: self._handle_accueil,
+            Mode.MUSIQUE: self._handle_musique,
+            Mode.IA: self._handle_ia,
+            Mode.CALIBRATION: self._handle_calibration,
+            Mode.SLEEP: self._handle_sleep,
+        }
+
+    def set_mode(self, mode: Mode) -> None:
+        LOGGER.info("Switching mode %s -> %s", self.mode, mode)
+        self.mode = mode
+
+    def step(self) -> None:
+        """Run one iteration of the state machine."""
+        handler = self.handlers.get(self.mode)
+        if handler:
+            handler()
+
+    def _handle_idle(self) -> None:
+        LOGGER.debug("Idle mode running")
+
+    def _handle_accueil(self) -> None:
+        LOGGER.debug("Accueil mode running")
+        self.set_mode(Mode.IDLE)
+
+    def _handle_musique(self) -> None:
+        LOGGER.debug("Musique mode running")
+        self.set_mode(Mode.IDLE)
+
+    def _handle_ia(self) -> None:
+        LOGGER.debug("IA mode running")
+        self.set_mode(Mode.IDLE)
+
+    def _handle_calibration(self) -> None:
+        LOGGER.debug("Calibration mode running")
+        self.set_mode(Mode.IDLE)
+
+    def _handle_sleep(self) -> None:
+        LOGGER.debug("Sleep mode running")
+

--- a/systemd/skull.service
+++ b/systemd/skull.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=SkullPi robot service
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/SkullPi
+ExecStart=/usr/bin/python3 /opt/SkullPi/main.py
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/halloween.json
+++ b/templates/halloween.json
@@ -1,0 +1,17 @@
+{
+  "name": "Halloween",
+  "phrases": {
+    "welcome": "Boo ! Bienvenue dans ma maison hantée...",
+    "goodbye": "Adieu... à bientôt dans l'ombre !"
+  },
+  "idle": {
+    "head_scan": { "amplitude_deg": 20, "period_sec": 12 },
+    "eye_saccades": { "amplitude_deg": 5, "frequency_hz": 0.3 }
+  },
+  "music": {
+    "default_mp3": "assets/halloween_theme.mp3"
+  },
+  "voice": {
+    "tts_voice": "fr+m3"
+  }
+}

--- a/templates_web/index.html
+++ b/templates_web/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>SkullPi</title>
+  </head>
+  <body>
+    <h1>SkullPi Control Panel</h1>
+    <p>Placeholder web interface.</p>
+  </body>
+</html>

--- a/tests/test_skull.py
+++ b/tests/test_skull.py
@@ -1,0 +1,11 @@
+import pytest
+from motors import Servo
+
+
+def test_servo_respects_soft_limits():
+    servo = Servo(channel=0, min_angle=100, max_angle=500, idle=300)
+
+    assert servo.set_position(300) == 300
+    assert servo.set_position(50) == 100
+    assert servo.set_position(600) == 500
+

--- a/tts.py
+++ b/tts.py
@@ -1,0 +1,50 @@
+"""Simple Text-to-Speech wrapper using ``espeak-ng``."""
+
+from __future__ import annotations
+
+import audioop
+import subprocess
+import wave
+from contextlib import closing
+from pathlib import Path
+from typing import Optional
+
+from logger import LOGGER
+
+TMP_WAV = Path("tts_output.wav")
+
+
+def synthesize(text: str, voice: str = "fr+m3") -> Optional[float]:
+    """Synthesize *text* into a WAV file and return its RMS value.
+
+    The RMS can be used to drive the jaw servo for basic lip-sync.
+
+    Parameters
+    ----------
+    text: str
+        Sentence to speak.
+    voice: str, default ``"fr+m3"``
+        Voice to use with ``espeak-ng``.
+
+    Returns
+    -------
+    Optional[float]
+        Root mean square of the generated audio or ``None`` on failure.
+    """
+    cmd = ["espeak-ng", "-v", voice, "-w", str(TMP_WAV), text]
+    try:
+        subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except Exception as exc:  # pragma: no cover - fails if espeak absent
+        LOGGER.error("TTS synthesis failed: %s", exc)
+        return None
+
+    try:
+        with closing(wave.open(str(TMP_WAV), "rb")) as wf:
+            frames = wf.readframes(wf.getnframes())
+            rms = audioop.rms(frames, wf.getsampwidth())
+            LOGGER.info("Synthesised %s with RMS=%s", text, rms)
+            return float(rms)
+    except Exception as exc:  # pragma: no cover
+        LOGGER.error("Failed to analyse wav: %s", exc)
+        return None
+

--- a/vision.py
+++ b/vision.py
@@ -1,0 +1,36 @@
+"""Vision and face tracking utilities (stub)."""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+from logger import LOGGER
+
+try:  # pragma: no cover
+    import cv2
+except Exception:  # pragma: no cover
+    cv2 = None  # type: ignore
+
+
+def capture_frame() -> Optional[Tuple[int, int]]:
+    """Capture a single frame and return its dimensions.
+
+    This function serves as a lightweight self-test that the camera can be
+    accessed. It returns the width and height if successful.
+    """
+    if not cv2:
+        LOGGER.warning("OpenCV not available")
+        return None
+    cap = cv2.VideoCapture(0)
+    if not cap.isOpened():
+        LOGGER.error("Unable to open camera")
+        return None
+    ret, frame = cap.read()
+    cap.release()
+    if not ret:
+        LOGGER.error("Failed to capture frame")
+        return None
+    height, width = frame.shape[:2]
+    LOGGER.info("Captured frame %sx%s", width, height)
+    return width, height
+

--- a/webapp.py
+++ b/webapp.py
@@ -1,0 +1,39 @@
+"""Minimal Flask web interface."""
+
+from __future__ import annotations
+
+from flask import Flask, jsonify, request
+
+from logger import LOGGER
+from motors import MotorController, Servo
+
+app = Flask(__name__)
+controller = MotorController()
+
+
+@app.route("/move", methods=["POST"])
+def move() -> tuple[str, int]:
+    """Move a servo via HTTP POST.
+
+    Expected JSON body::
+
+        {"name": "jaw", "pulse": 300}
+    """
+    data = request.get_json(force=True)
+    name = data.get("name")
+    pulse = int(data.get("pulse", 0))
+    result = controller.move(name, pulse)
+    if result is None:
+        return jsonify({"error": "unknown servo"}), 400
+    return jsonify({"pulse": result}), 200
+
+
+def run(host: str = "0.0.0.0", port: int = 5000) -> None:
+    """Run the Flask development server."""
+    LOGGER.info("Starting web application on %s:%s", host, port)
+    app.run(host=host, port=port)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    run()
+


### PR DESCRIPTION
## Summary
- Scaffold modular Python package for SkullPi, including servo control, configuration, logging and supervisor state machine
- Provide stubs for vision, audio, TTS, web interface and safety features
- Add example configuration, templates and systemd service

## Testing
- `python -m py_compile *.py`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1f804d0d883218cc7dad4c65a50d8